### PR TITLE
Enhance Role-Based Authorization for API Endpoints

### DIFF
--- a/src/main/java/com/springboot/heathcare/User/CustomUserDetailsService.java
+++ b/src/main/java/com/springboot/heathcare/User/CustomUserDetailsService.java
@@ -1,11 +1,11 @@
 package com.springboot.heathcare.User;
 
-import com.springboot.heathcare.User.User;
-import com.springboot.heathcare.User.UserRepository;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import java.util.Collections;
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
@@ -24,7 +24,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         return org.springframework.security.core.userdetails.User.builder()
                 .username(user.getEmail()) // Use email as username
                 .password(user.getPassword()) //  Ensure password is stored securely
-                .roles("USER") //  Assign user role (adjust if needed)
+                .authorities(Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name()))) //  Assign user role (adjust if needed)
                 .build();
     }
 

--- a/src/main/java/com/springboot/heathcare/User/LoginDto.java
+++ b/src/main/java/com/springboot/heathcare/User/LoginDto.java
@@ -1,6 +1,7 @@
 package com.springboot.heathcare.User;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
@@ -10,4 +11,7 @@ public class LoginDto {
 
     @NotBlank
     private String password;
+
+    @NotNull
+    private Role role;
 }

--- a/src/main/java/com/springboot/heathcare/User/Role.java
+++ b/src/main/java/com/springboot/heathcare/User/Role.java
@@ -1,0 +1,5 @@
+package com.springboot.heathcare.User;
+
+public enum Role {
+    PATIENT , DOCTOR , ADMIN
+}

--- a/src/main/java/com/springboot/heathcare/User/User.java
+++ b/src/main/java/com/springboot/heathcare/User/User.java
@@ -38,4 +38,7 @@ public class User {
     @Pattern(message = "choose the strongest password", regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$ ")
     private String password;
 
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
 }

--- a/src/main/java/com/springboot/heathcare/appointment/AppointmentController.java
+++ b/src/main/java/com/springboot/heathcare/appointment/AppointmentController.java
@@ -3,13 +3,16 @@ package com.springboot.heathcare.appointment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/appointments")
+@PreAuthorize("hasAnyAuthority('PATIENT', 'DOCTOR')")
 @RequiredArgsConstructor
+
 public class AppointmentController {
 
     private final AppointmentService appointmentService;

--- a/src/main/java/com/springboot/heathcare/appointment/AppointmentService.java
+++ b/src/main/java/com/springboot/heathcare/appointment/AppointmentService.java
@@ -51,7 +51,7 @@ public class AppointmentService {
         appoint.setStatus(appointment.getStatus());
         appoint.setNotes(appointment.getNotes());
         appoint.setAppointmentDate(appointment.getAppointmentDate());
-        return appointmentRepository.save(appointment);
+        return appointmentRepository.save(appoint);
     }
 
     public void deleteAppointment(Long id) {

--- a/src/main/java/com/springboot/heathcare/clinic/ClinicController.java
+++ b/src/main/java/com/springboot/heathcare/clinic/ClinicController.java
@@ -3,6 +3,7 @@ package com.springboot.heathcare.clinic;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/clinics")
 @RequiredArgsConstructor
+@PreAuthorize("hasAuthority('ADMIN')")
 public class ClinicController {
 
     private final ClinicService clinicService;

--- a/src/main/java/com/springboot/heathcare/doctor/DoctorController.java
+++ b/src/main/java/com/springboot/heathcare/doctor/DoctorController.java
@@ -3,6 +3,7 @@ package com.springboot.heathcare.doctor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/doctors")
 @RequiredArgsConstructor
+@PreAuthorize("hasAuthority('DOCTOR')")
 public class DoctorController {
 
     private final DoctorService doctorService;

--- a/src/main/java/com/springboot/heathcare/medicalRecord/MedicalRecordController.java
+++ b/src/main/java/com/springboot/heathcare/medicalRecord/MedicalRecordController.java
@@ -3,6 +3,7 @@ package com.springboot.heathcare.medicalRecord;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/medical-records")
 @RequiredArgsConstructor
+@PreAuthorize("hasAuthority('ADMIN')")
 public class MedicalRecordController {
 
     private final MedicalRecordService medicalRecordService;

--- a/src/main/java/com/springboot/heathcare/patient/PatientController.java
+++ b/src/main/java/com/springboot/heathcare/patient/PatientController.java
@@ -3,12 +3,14 @@ package com.springboot.heathcare.patient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/patients")
+@PreAuthorize("hasAuthority('PATIENT')")
 @RequiredArgsConstructor
 public class PatientController {
 


### PR DESCRIPTION
This PR introduces role-based access control (RBAC) by integrating Spring Security's @PreAuthorize annotations into controllers. Users must now have specific roles (PATIENT, DOCTOR, ADMIN) to access different API endpoints.

**Key Changes:**
Applied _@PreAuthorize_ annotations to enforce restricted access for each endpoint.

Users must include their role in JWT authentication to access endpoints.

Ensured fine-grained access control:

- Patients → /patients/** and /appointments/**
- 
- Doctors → /doctors/** and /appointments/**
- 
- Admins → /medicalrecords/** and /clinics/**

**Updated Controllers:**

- Patient Controller (@PreAuthorize("hasAuthority('PATIENT')"))
 Limits access to patient-related endpoints only for PATIENT role.

- Doctor Controller (@PreAuthorize("hasAuthority('DOCTOR')"))
 Restricts /doctors/** endpoints only for DOCTOR role.

- Appointment Controller (@PreAuthorize("hasAnyAuthority('PATIENT', 'DOCTOR')"))
 Allows both Patients & Doctors to access appointment-related endpoints.
 
- Admin (Clinic) Controller (@PreAuthorize("hasAuthority('ADMIN')"))
 Grants access only to ADMIN role for managing clinics and medical records.